### PR TITLE
Add delete command and enforce working directory validation

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="084c0317-2b36-4e4a-8494-56cab8660877" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/rplc/bin/cli.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/bin/cli.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/rplc/lib/config.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/lib/config.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/rplc/lib/mirror.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/lib/mirror.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/lib/test_mirror.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/lib/test_mirror.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/bin/test_cli.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/bin/test_cli.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -95,7 +92,7 @@
       <workItem from="1755416140741" duration="622000" />
       <workItem from="1755423341451" duration="2443000" />
       <workItem from="1755503368086" duration="3199000" />
-      <workItem from="1760013317465" duration="915000" />
+      <workItem from="1760013317465" duration="1599000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="084c0317-2b36-4e4a-8494-56cab8660877" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/rplc/bin/cli.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/bin/cli.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/rplc/lib/config.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/lib/config.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/rplc/lib/mirror.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/rplc/lib/mirror.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/lib/test_mirror.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/lib/test_mirror.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -24,28 +29,28 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;Python tests.pytest for test_cli.test_cli_info_basic_display.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Python tests.pytest for test_cli.test_cli_info_basic_display.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "git-widget-placeholder": "feat/delete",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.pluginManager",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;Markdown&quot;
+  "keyToStringList": {
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "Markdown"
     ]
   }
-}</component>
+}]]></component>
   <component name="RunManager">
     <configuration name="pytest for test_cli.test_cli_info_basic_display" type="tests" factoryName="py.test" temporary="true" nameIsGenerated="true">
       <module name="rplc" />
@@ -73,8 +78,8 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-js-predefined-d6986cc7102b-e03c56caf84a-JavaScript-PY-252.23892.439" />
-        <option value="bundled-python-sdk-b3ae9b5d7125-f0eec537fc84-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-252.23892.439" />
+        <option value="bundled-js-predefined-d6986cc7102b-3aa1da707db6-JavaScript-PY-252.26830.99" />
+        <option value="bundled-python-sdk-164cda30dcd9-0af03a5fa574-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-252.26830.99" />
       </set>
     </attachedChunks>
   </component>
@@ -90,6 +95,7 @@
       <workItem from="1755416140741" duration="622000" />
       <workItem from="1755423341451" duration="2443000" />
       <workItem from="1755503368086" duration="3199000" />
+      <workItem from="1760013317465" duration="915000" />
     </task>
     <servers />
   </component>

--- a/README.md
+++ b/README.md
@@ -203,6 +203,53 @@ rplc swapout --pattern "*.yml"
 rplc swapout --exclude "*.log"
 ```
 
+#### `delete`
+Remove files/directories from rplc management.
+
+```bash
+rplc delete [FILES...] [OPTIONS]
+```
+
+**Important:** This command only works when files are swapped out (in their original state). Use `rplc swapout` first if files are currently swapped in.
+
+**What it removes:**
+- Mirror directory content
+- Backup files (`.rplc.original`)
+- Configuration file entries
+
+**Arguments:**
+- `FILES...`: Specific files or directories to remove from management (space-separated)
+
+**Options:**
+- `--pattern, -g`: Glob pattern for file selection
+- `--exclude, -x`: Exclude patterns (can be used multiple times)
+- `--proj-dir, -p`: Project directory (env: `RPLC_PROJ_DIR`)
+- `--mirror-dir, -m`: Mirror directory (env: `RPLC_MIRROR_DIR`)
+- `--config, -c`: Configuration file (env: `RPLC_CONFIG`)
+- `--no-env`: Disable `.envrc` management (env: `RPLC_NO_ENV`)
+
+**Examples:**
+```bash
+# Remove a specific file from management
+rplc delete main/resources/application.yml
+
+# Remove multiple files
+rplc delete main/resources/application.yml main/src/class.java
+
+# Remove using glob patterns
+rplc delete --pattern "*.yml"
+
+# Remove a directory
+rplc delete scratchdir/
+
+# Remove all except certain files
+rplc delete --pattern "main/**/*" --exclude "*.log"
+
+# If file is swapped in, you'll get an error:
+# Error: Cannot delete - currently swapped in
+# Run 'rplc swapout' first to restore original state
+```
+
 ### Configuration Format
 
 Configuration files use Markdown format with a specific structure. Only content under the `# Development` → `## rplc-config` section is processed:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,46 @@ rplc swapout --config rplc-config.md
 rplc swapout main/resources/application.yml --config rplc-config.md
 ```
 
+## Working Directory Requirements
+
+**IMPORTANT:** `rplc` must be run from within your project directory (or any subdirectory).
+
+The tool validates that your current working directory is within the project directory to prevent accidental operations on the wrong files.
+
+### Project Detection
+
+When no `RPLC_PROJ_DIR` is set, `rplc` looks for project markers in the current directory:
+- `.git/` - Git repository
+- `.envrc` - direnv configuration
+- `.rplc` - rplc marker file (create this to mark your project root)
+- `README.md`, `pyproject.toml`, `package.json` - Common project files
+
+**If no markers are found**, you must either:
+1. Set the `RPLC_PROJ_DIR` environment variable
+2. Use the `--proj-dir` flag
+3. Create a `.rplc` marker file in your project root
+
+### Examples
+
+```bash
+# ✓ Running from project root
+cd /path/to/myproject
+rplc swapin
+
+# ✓ Running from subdirectory
+cd /path/to/myproject/src
+rplc swapin
+
+# ✗ Running from parent directory (will fail)
+cd /path/to
+rplc swapin --proj-dir myproject  # Error: not within project directory
+
+# ✓ Using environment variable
+export RPLC_PROJ_DIR=/path/to/myproject
+cd /anywhere/within/myproject
+rplc swapin
+```
+
 ## Environment Variables
 
 RPLC can be configured using environment variables, which serve as defaults when command-line options are not provided:
@@ -99,7 +139,7 @@ RPLC can be configured using environment variables, which serve as defaults when
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
 | `RPLC_CONFIG` | Path to configuration file | `sample.md` |
-| `RPLC_PROJ_DIR` | Project directory path | Current directory |
+| `RPLC_PROJ_DIR` | Project directory path | Auto-detected from cwd |
 | `RPLC_MIRROR_DIR` | Mirror directory path | `../mirror_proj` |
 | `RPLC_NO_ENV` | Disable .envrc management | `false` |
 
@@ -340,6 +380,29 @@ Swapped State:    Sentinel files exist, RPLC_SWAPPED=1
 
 ## Troubleshooting
 
+### Common Errors
+
+**Error: "rplc must be run from within the project directory"**
+
+This means you're trying to run `rplc` from a directory that's not within your project.
+
+Solutions:
+1. `cd` into your project directory or any subdirectory within it
+2. Set `RPLC_PROJ_DIR` environment variable to your project path
+3. Use `--proj-dir` flag (but still run from within that directory)
+
+**Warning: "Current directory doesn't appear to be a project root"**
+
+This occurs when no project markers are found in the current directory and `RPLC_PROJ_DIR` is not set.
+
+Solutions:
+1. Ensure you're in the correct project directory
+2. Create a `.rplc` marker file: `touch .rplc`
+3. Set `RPLC_PROJ_DIR` environment variable
+4. Use `--proj-dir` flag explicitly
+
+### General Troubleshooting
+
 ```bash
 # Show detailed help for any command
 rplc --help
@@ -348,8 +411,11 @@ rplc swapin --help
 # Show current configuration and status
 rplc info
 
-# Enable verbose output (if available)
+# Enable verbose output
 rplc -v swapin
+
+# Check which directory rplc thinks is the project
+rplc info  # Shows project directory in configuration table
 ```
 
 ## Development

--- a/src/rplc/bin/cli.py
+++ b/src/rplc/bin/cli.py
@@ -213,9 +213,16 @@ def info(
 
 @app.command()
 def swapin(
-    files: Annotated[Optional[List[str]], typer.Argument(help="Files/directories to swap in")] = None,
-    pattern: Annotated[Optional[str], typer.Option("--pattern", "-g", help="Glob pattern for file selection")] = None,
-    exclude: Annotated[Optional[List[str]], typer.Option("--exclude", "-x", help="Exclude patterns")] = None,
+    files: Annotated[
+        Optional[List[str]], typer.Argument(help="Files/directories to swap in")
+    ] = None,
+    pattern: Annotated[
+        Optional[str],
+        typer.Option("--pattern", "-g", help="Glob pattern for file selection"),
+    ] = None,
+    exclude: Annotated[
+        Optional[List[str]], typer.Option("--exclude", "-x", help="Exclude patterns")
+    ] = None,
     proj_dir: Annotated[
         Optional[Path],
         typer.Option(
@@ -263,9 +270,16 @@ def swapin(
 
 @app.command()
 def swapout(
-    files: Annotated[Optional[List[str]], typer.Argument(help="Files/directories to swap out")] = None,
-    pattern: Annotated[Optional[str], typer.Option("--pattern", "-g", help="Glob pattern for file selection")] = None,
-    exclude: Annotated[Optional[List[str]], typer.Option("--exclude", "-x", help="Exclude patterns")] = None,
+    files: Annotated[
+        Optional[List[str]], typer.Argument(help="Files/directories to swap out")
+    ] = None,
+    pattern: Annotated[
+        Optional[str],
+        typer.Option("--pattern", "-g", help="Glob pattern for file selection"),
+    ] = None,
+    exclude: Annotated[
+        Optional[List[str]], typer.Option("--exclude", "-x", help="Exclude patterns")
+    ] = None,
     proj_dir: Annotated[
         Optional[Path],
         typer.Option(
@@ -309,6 +323,75 @@ def swapout(
         manage_env=not no_env,
     )
     manager.swap_out(files=files, pattern=pattern, exclude=exclude)
+
+
+@app.command()
+def delete(
+    files: Annotated[
+        Optional[List[str]], typer.Argument(help="Files/directories to remove from management")
+    ] = None,
+    pattern: Annotated[
+        Optional[str],
+        typer.Option("--pattern", "-g", help="Glob pattern for file selection"),
+    ] = None,
+    exclude: Annotated[
+        Optional[List[str]], typer.Option("--exclude", "-x", help="Exclude patterns")
+    ] = None,
+    proj_dir: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--proj-dir",
+            "-p",
+            help="Project directory containing original files (env: RPLC_PROJ_DIR)",
+        ),
+    ] = None,
+    mirror_dir: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--mirror-dir",
+            "-m",
+            help="Directory containing mirrored files (env: RPLC_MIRROR_DIR)",
+        ),
+    ] = None,
+    config: Annotated[
+        Optional[Path],
+        typer.Option("--config", "-c", help="Path to config file (env: RPLC_CONFIG)"),
+    ] = None,
+    no_env: Annotated[
+        Optional[bool],
+        typer.Option("--no-env", help="Disable .envrc management (env: RPLC_NO_ENV)"),
+    ] = None,
+) -> None:
+    """
+    Remove files/directories from rplc management.
+
+    This command removes mirror artifacts and configuration entries for the specified
+    files/directories. It only works when files are swapped out to avoid data loss.
+
+    Removes:
+    - Mirror directory artifacts
+    - Backup files (.rplc.original)
+    - Configuration file entries
+
+    Use 'rplc swapout' first if files are currently swapped in.
+    """
+    # Use environment variables as defaults if options not provided
+    proj_dir = proj_dir or get_default_proj_dir()
+    mirror_dir = mirror_dir or get_default_mirror_dir()
+    config = config or get_default_config()
+    no_env = no_env if no_env is not None else get_default_no_env()
+
+    config_file = config.resolve()
+    if not config_file.exists():
+        typer.echo(f"Error: Config file {config_file} not found")
+        raise typer.Exit(1)
+    manager = MirrorManager(
+        config_file,
+        proj_dir=proj_dir.resolve(),
+        mirror_dir=mirror_dir.resolve(),
+        manage_env=not no_env,
+    )
+    manager.delete(files=files, pattern=pattern, exclude=exclude)
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary

This PR adds two major features to rplc:

1. **Delete command** - Remove files/directories from rplc management
2. **Working directory validation** - Ensure rplc is run from within the project directory

## Delete Command

Adds a new `delete` command that removes files/directories from rplc management by cleaning up mirror artifacts and configuration entries.

### Key Features
- Only operates when files are swapped out (safety first)
- Removes mirror content, backup files (.rplc.original), and config entries
- Supports file-specific, pattern-based, and exclusion filtering
- Verbose output showing every action taken
- Clear error messages if files are swapped in

## Breaking Changes

None. The working directory validation is strict but provides clear guidance when it fails. Users running from within their project directory will see no change in behavior.