### PR TITLE
feat: detect and report orphaned artifacts after swap-out

### DIFF
--- a/src/rplc/lib/mirror.py
+++ b/src/rplc/lib/mirror.py
@@ -224,6 +224,19 @@ class MirrorManager:
 
             print(f"[green]Swapped out: {rel_path}[/green]")
 
+        # Report orphaned artifacts (only when no filters applied, i.e. no partial swapout)
+        if not any([files, pattern, exclude]):
+            orphaned_sentinels, orphaned_backups = self.find_orphaned_artifacts()
+            if orphaned_sentinels or orphaned_backups:
+                print()
+                print("[yellow]Warning: Found orphaned rplc artifacts:[/yellow]")
+                for sentinel in orphaned_sentinels:
+                    print(f"  [dim]Sentinel: {sentinel}[/dim]")
+                for backup in orphaned_backups:
+                    print(f"  [dim]Backup: {backup}[/dim]")
+                print("[dim]These may be from removed/renamed config entries.[/dim]")
+                print("[dim]Delete manually if not needed.[/dim]")
+
     def delete(self, files: Optional[List[str]] = None, pattern: Optional[str] = None, exclude: Optional[List[str]] = None) -> None:
         """
         Remove paths from rplc management - only works when swapped out.
@@ -407,6 +420,20 @@ class MirrorManager:
         hostname = get_hostname()
         rel_path = config.source_path.relative_to(self.proj_dir)
         return (self.mirror_dir / f"{rel_path}.{hostname}.rplc_active").resolve()
+
+    def find_orphaned_artifacts(self) -> Tuple[List[Path], List[Path]]:
+        """Find orphaned sentinel and backup files in mirror directory.
+
+        After a full swap-out, no sentinel or backup files should remain.
+        Any file with these suffixes is orphaned by definition.
+
+        Returns:
+            Tuple of (orphaned_sentinels, orphaned_backups)
+        """
+        orphaned_sentinels = list(self.mirror_dir.rglob("*.rplc_active"))
+        orphaned_backups = list(self.mirror_dir.rglob(f"*{self.ORIGINAL_SUFFIX}"))
+
+        return orphaned_sentinels, orphaned_backups
 
     def _find_any_sentinel(self, config: MirrorConfig) -> Tuple[Optional[Path], Optional[str]]:
         """Find sentinel for any host.

--- a/tests/lib/test_mirror.py
+++ b/tests/lib/test_mirror.py
@@ -814,3 +814,133 @@ def test_swap_in_rejects_bare_gitignore(test_project: tuple[Path, Path], test_co
         manager2.swap_in(files=["config/.gitignore"])
     assert exc_info.value.code == 1
     assert (mirror_dir / "config/.gitignore").exists()  # unchanged
+
+
+# ==============================================================================
+# Orphaned artifact detection tests
+# ==============================================================================
+
+
+def test_find_orphaned_artifacts_finds_sentinel(test_project: tuple[Path, Path], test_config_file: Path) -> None:
+    """Test that find_orphaned_artifacts detects any sentinel file"""
+    proj_dir, mirror_dir = test_project
+    manager = MirrorManager(
+        config_file=test_config_file,
+        proj_dir=proj_dir,
+        mirror_dir=mirror_dir
+    )
+
+    # Create sentinel file (any sentinel after swap-out is orphaned)
+    orphan_dir = mirror_dir / "some/path"
+    orphan_dir.mkdir(parents=True)
+    sentinel = mirror_dir / "some/path/file.txt.somehost.rplc_active"
+    sentinel.write_text("sentinel content")
+
+    # Find orphaned artifacts
+    orphaned_sentinels, orphaned_backups = manager.find_orphaned_artifacts()
+
+    # Should find the sentinel
+    assert len(orphaned_sentinels) == 1
+    assert sentinel in orphaned_sentinels
+    assert len(orphaned_backups) == 0
+
+
+def test_find_orphaned_artifacts_finds_backup(test_project: tuple[Path, Path], test_config_file: Path) -> None:
+    """Test that find_orphaned_artifacts detects any backup file"""
+    proj_dir, mirror_dir = test_project
+    manager = MirrorManager(
+        config_file=test_config_file,
+        proj_dir=proj_dir,
+        mirror_dir=mirror_dir
+    )
+
+    # Create orphaned backup (path not in config)
+    orphan_dir = mirror_dir / "orphaned/path"
+    orphan_dir.mkdir(parents=True)
+    orphan_backup = mirror_dir / "orphaned/path/file.txt.rplc.original"
+    orphan_backup.write_text("orphan backup content")
+
+    # Find orphaned artifacts
+    orphaned_sentinels, orphaned_backups = manager.find_orphaned_artifacts()
+
+    # Should find the orphan backup
+    assert len(orphaned_backups) == 1
+    assert orphan_backup in orphaned_backups
+    assert len(orphaned_sentinels) == 0
+
+
+def test_orphaned_artifacts_reported_on_swapout(test_project: tuple[Path, Path], test_config_file: Path, capsys) -> None:
+    """Test that swap_out reports orphaned artifacts when no filters applied"""
+    proj_dir, mirror_dir = test_project
+    manager = MirrorManager(
+        config_file=test_config_file,
+        proj_dir=proj_dir,
+        mirror_dir=mirror_dir
+    )
+
+    # Create orphaned sentinel
+    orphan_dir = mirror_dir / "orphaned"
+    orphan_dir.mkdir(parents=True)
+    orphan_sentinel = orphan_dir / "file.txt.somehost.rplc_active"
+    orphan_sentinel.write_text("orphan")
+
+    # Swap in then swap out (full, no filters)
+    manager.swap_in()
+    manager.swap_out()
+
+    # Should report the orphan
+    captured = capsys.readouterr()
+    assert "orphan" in captured.out.lower() or "Orphaned" in captured.out
+    assert "file.txt" in captured.out
+
+    # Orphan should still exist (not auto-deleted)
+    assert orphan_sentinel.exists()
+
+
+def test_orphaned_report_skipped_with_pattern(test_project: tuple[Path, Path], test_config_file: Path, capsys) -> None:
+    """Test that pattern-based swap_out does NOT report orphans"""
+    proj_dir, mirror_dir = test_project
+    manager = MirrorManager(
+        config_file=test_config_file,
+        proj_dir=proj_dir,
+        mirror_dir=mirror_dir
+    )
+
+    # Create orphaned sentinel
+    orphan_dir = mirror_dir / "orphaned"
+    orphan_dir.mkdir(parents=True)
+    orphan_sentinel = orphan_dir / "file.txt.somehost.rplc_active"
+    orphan_sentinel.write_text("orphan")
+
+    # Swap in all, then swap out with pattern
+    manager.swap_in()
+    capsys.readouterr()  # Clear output
+
+    manager.swap_out(pattern="*.yml")
+
+    # Should NOT report orphans (intentional partial swapout)
+    captured = capsys.readouterr()
+    assert "orphan" not in captured.out.lower()
+
+
+def test_orphaned_sentinel_from_other_host_detected(test_project: tuple[Path, Path], test_config_file: Path) -> None:
+    """Test that orphaned sentinels from other hosts are also detected"""
+    proj_dir, mirror_dir = test_project
+    manager = MirrorManager(
+        config_file=test_config_file,
+        proj_dir=proj_dir,
+        mirror_dir=mirror_dir
+    )
+
+    # Create orphaned sentinel from a different host
+    orphan_dir = mirror_dir / "orphaned"
+    orphan_dir.mkdir(parents=True)
+    orphan_sentinel = orphan_dir / "file.txt.otherhost.rplc_active"
+    orphan_sentinel.write_text("orphan from other host")
+
+    # Find orphaned artifacts
+    orphaned_sentinels, _ = manager.find_orphaned_artifacts()
+
+    # Should detect it regardless of hostname
+    assert len(orphaned_sentinels) == 1
+    assert orphan_sentinel in orphaned_sentinels

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,7 @@ wheels = [
 
 [[package]]
 name = "rplc"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Summary

- Add `find_orphaned_artifacts()` method to detect leftover sentinel and backup files after swap-out
- Report warnings at end of full swap-out when orphaned artifacts are found
- User decides cleanup - no automatic deletion

## Problem

When structural changes occur while files are swapped in (config entries edited/removed, files moved/deleted), sentinel files (`*.rplc_active`) and backup files (`*.rplc.original`) can become orphaned because `swap_out()` only processes paths from the current config.

## Solution

After a full swap-out (no pattern/file filters), scan the mirror directory for any remaining artifacts. Any sentinel or backup file found after swap-out is orphaned by definition - they should have been cleaned up during the swap-out process.
